### PR TITLE
Update BaseActivity.kt

### DIFF
--- a/app/src/main/java/me/immathan/kotlinlogin/ui/base/BaseActivity.kt
+++ b/app/src/main/java/me/immathan/kotlinlogin/ui/base/BaseActivity.kt
@@ -59,7 +59,13 @@ abstract class BaseActivity : AppCompatActivity(), MvpView {
     }
 
     override fun hideProgress() {
-        mProgressDialog?.hide()
+        
+        mProgressDialog?.let{dialog->
+             if(dialog.isShowing){
+             dialog.hide()
+            }
+        }
+      
     }
 
     override fun showMessage(message: String) {


### PR DESCRIPTION
A common error that can happen with progress dialogs is to hide the same even if it is not showing. So a safe thing is to check whether it is showing or not before hiding it